### PR TITLE
Fix/anchor encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     }
   },
   "files": [
-    "./build/**/*"
+    "./build/**/*",
+    "./src/**/*"
   ],
   "scripts": {
     "build": "rm -rf ./build && concurrently \"tsc -p tsconfig.json && resolve-tspaths -p tsconfig.json && sh ./fix-pkg.sh node/esm module && yarn tsc-esm-fix --tsconfig tsconfig.json \" \"tsc -p cjs.tsconfig.json && resolve-tspaths -p cjs.tsconfig.json && sh ./fix-pkg.sh node/cjs commonjs \"  \"tsc -p web.tsconfig.json && resolve-tspaths -p web.tsconfig.json && sh ./fix-pkg.sh web/esm module && yarn tsc-esm-fix --tsconfig web.tsconfig.json \" \"tsc -p web-cjs.tsconfig.json && resolve-tspaths -p web-cjs.tsconfig.json && sh ./fix-pkg.sh web/cjs commonjs\" && webpack",

--- a/src/DataItem.ts
+++ b/src/DataItem.ts
@@ -10,6 +10,7 @@ import { SIG_CONFIG, SignatureConfig } from "./constants";
 import { getCryptoDriver } from "$/utils";
 import { deserializeTags } from "./tags";
 import { createHash } from "crypto";
+import type { Base64URLString } from "./types";
 
 export const MIN_BINARY_SIZE = 80;
 export const MAX_TAG_BYTES = 4096;
@@ -38,7 +39,7 @@ export class DataItem implements BundleItem {
     return DataItem.verify(this.binary);
   }
 
-  get id(): string {
+  get id(): Base64URLString {
     return base64url.encode(this.rawId);
   }
 
@@ -58,7 +59,7 @@ export class DataItem implements BundleItem {
     return this.binary.subarray(2, 2 + this.signatureLength);
   }
 
-  get signature(): string {
+  get signature(): Base64URLString {
     return base64url.encode(this.rawSignature);
   }
 
@@ -76,7 +77,7 @@ export class DataItem implements BundleItem {
     return SIG_CONFIG[this.signatureType].sigLength;
   }
 
-  get owner(): string {
+  get owner(): Base64URLString {
     return base64url.encode(this.rawOwner);
   }
 
@@ -90,7 +91,7 @@ export class DataItem implements BundleItem {
     return isPresent ? this.binary.subarray(targetStart + 1, targetStart + 33) : Buffer.alloc(0);
   }
 
-  get target(): string {
+  get target(): Base64URLString {
     return base64url.encode(this.rawTarget);
   }
 
@@ -101,8 +102,8 @@ export class DataItem implements BundleItem {
     return isPresent ? this.binary.subarray(anchorStart + 1, anchorStart + 33) : Buffer.alloc(0);
   }
 
-  get anchor(): string {
-    return this.rawAnchor.toString();
+  get anchor(): Base64URLString {
+    return base64url.encode(this.rawAnchor); /* .toString(); */
   }
 
   get rawTags(): Buffer {
@@ -123,7 +124,7 @@ export class DataItem implements BundleItem {
     return deserializeTags(Buffer.from(this.binary.subarray(tagsStart + 16, tagsStart + 16 + tagsSize)));
   }
 
-  get tagsB64Url(): { name: string; value: string }[] {
+  get tagsB64Url(): { name: Base64URLString; value: Base64URLString }[] {
     const _tags = this.tags;
     return _tags.map((t) => ({
       name: base64url.encode(t.name),
@@ -149,7 +150,7 @@ export class DataItem implements BundleItem {
     return this.binary.subarray(dataStart, this.binary.length);
   }
 
-  get data(): string {
+  get data(): Base64URLString {
     return base64url.encode(this.rawData);
   }
 
@@ -184,7 +185,7 @@ export class DataItem implements BundleItem {
     data: string;
     signature: string;
     target: string;
-    tags: { name: string; value: string }[];
+    tags: { name: Base64URLString; value: Base64URLString }[];
   } {
     return {
       signature: this.signature,

--- a/src/__tests__/dataItem.spec.ts
+++ b/src/__tests__/dataItem.spec.ts
@@ -75,7 +75,7 @@ describe("DataItem", () => {
             });
             describe("given we want to get the anchor", () => {
               it("should return the anchor", async () => {
-                expect(dataItem.anchor).toEqual(anchor ?? "");
+                expect(dataItem.anchor).toEqual(base64url.encode(anchor ?? ""));
               });
             });
             describe("given we want to get the target", () => {

--- a/src/__tests__/filePolygon.spec.ts
+++ b/src/__tests__/filePolygon.spec.ts
@@ -1,6 +1,7 @@
 import { PolygonSigner, createData } from "../../index";
 import type { DataItemCreateOptions } from "../ar-data-base";
 import { createData as createFileData } from "../../src/file/index";
+import base64url from "base64url";
 
 describe("Polygon signing tests", function () {
   it("should sign and verify using non file", async function () {
@@ -48,7 +49,7 @@ describe("Polygon signing tests", function () {
     expect((await d.rawOwner()).toString("hex")).toEqual(signer.pk);
     expect(await d.signatureType()).toEqual(3);
     expect(await d.target()).toEqual("OXcT1sVRSA5eGwt2k6Yuz8-3e3g9WJi5uSE99CWqsBs");
-    expect(await d.anchor()).toEqual("Math.apt'#]gng(36).substring(30)");
+    expect(await d.anchor()).toEqual(base64url.encode("Math.apt'#]gng(36).substring(30)"));
     expect(await d.tags()).toEqual([{ name: "Content-Type", value: "image/png" }]);
     expect(Buffer.compare(Buffer.from("hello"), await d.rawData())).toEqual(0);
   });

--- a/src/__tests__/fileTests.spec.ts
+++ b/src/__tests__/fileTests.spec.ts
@@ -89,7 +89,7 @@ describe("DataItem", () => {
             });
             describe("given we want to get the anchor", () => {
               it("should return the anchor", async () => {
-                expect(await dataItem.anchor()).toEqual(anchor ?? "");
+                expect(await dataItem.anchor()).toEqual(base64url.encode(anchor ?? ""));
               });
             });
             describe("given we want to get the target", () => {

--- a/src/__tests__/polygon.spec.ts
+++ b/src/__tests__/polygon.spec.ts
@@ -1,3 +1,4 @@
+import base64url from "base64url";
 import { createData, PolygonSigner } from "../../index";
 import type { DataItemCreateOptions } from "../ar-data-base";
 
@@ -18,7 +19,7 @@ describe("Polygon signing tests", function () {
     expect(d.rawOwner.toString("hex")).toEqual(signer.pk);
     expect(d.signatureType).toEqual(3);
     expect(d.target).toEqual("OXcT1sVRSA5eGwt2k6Yuz8-3e3g9WJi5uSE99CWqsBs");
-    expect(d.anchor).toEqual("Math.apt'#]gng(36).substring(30)");
+    expect(d.anchor).toEqual(base64url.encode("Math.apt'#]gng(36).substring(30)"));
     expect(d.tags).toEqual([{ name: "Content-Type", value: "image/png" }]);
     expect(d.rawData.toString()).toEqual("hello");
   });

--- a/src/__tests__/signer.spec.ts
+++ b/src/__tests__/signer.spec.ts
@@ -16,6 +16,7 @@ import base58 from "bs58";
 import arweaveTestKey from "./test_key0.json";
 import { createData as createFileData } from "../file";
 import { Wallet } from "@ethersproject/wallet";
+import base64url from "base64url";
 
 const multiAptoskeyPairs = [
   {
@@ -260,7 +261,7 @@ describe("Signers()", function () {
                   expect(encodedOwner).toEqual(publicKey);
                   expect(dataItem.signatureType).toEqual(signerTestVariation.signatureType);
                   expect(dataItem.target).toEqual(targetTestVariation.target ?? "");
-                  expect(dataItem.anchor).toEqual(anchorTestVariation.anchor ?? "");
+                  expect(dataItem.anchor).toEqual(base64url.encode(anchorTestVariation.anchor ?? ""));
                   expect(dataItem.tags).toEqual(tags ?? []);
                 });
 
@@ -346,7 +347,7 @@ describe("Signers()", function () {
                   expect(encodedOwner).toEqual(publicKey);
                   expect(await dataItem.signatureType()).toEqual(signerTestVariation.signatureType);
                   expect(await dataItem.target()).toEqual(targetTestVariation.target ?? "");
-                  expect(await dataItem.anchor()).toEqual(anchorTestVariation.anchor ?? "");
+                  expect(await dataItem.anchor()).toEqual(base64url.encode(anchorTestVariation.anchor ?? ""));
                   expect(await dataItem.tags()).toEqual(tags ?? []);
                 });
 

--- a/src/__tests__/solana.spec.ts
+++ b/src/__tests__/solana.spec.ts
@@ -1,3 +1,4 @@
+import base64url from "base64url";
 import { SolanaSigner, createData } from "../../index";
 import type { DataItemCreateOptions } from "../ar-data-base";
 import base58 from "bs58";
@@ -18,7 +19,7 @@ describe("Solana signing tests", function () {
     expect(base58.encode(d.rawOwner)).toEqual(signer.pk);
     expect(d.signatureType).toEqual(2);
     expect(d.target).toEqual("OXcT1sVRSA5eGwt2k6Yuz8-3e3g9WJi5uSE99CWqsBs");
-    expect(d.anchor).toEqual("Math.apt'#]gng(36).substring(30)");
+    expect(d.anchor).toEqual(base64url.encode("Math.apt'#]gng(36).substring(30)"));
     expect(d.tags).toEqual([{ name: "Content-Type", value: "image/png" }]);
     expect(d.rawData.toString()).toEqual("hello");
   });

--- a/src/__tests__/tests.spec.ts
+++ b/src/__tests__/tests.spec.ts
@@ -4,6 +4,7 @@ import { Buffer } from "buffer";
 import * as fs from "fs";
 import type { DataItemCreateOptions } from "../../index";
 import { SolanaSigner, bundleAndSignData, DataItem, createData, ArweaveSigner } from "../../index";
+import base64url from "base64url";
 const wallet0 = JSON.parse(readFileSync(path.join(__dirname, "test_key0.json")).toString());
 
 describe("Creating and indexing a data item", function () {
@@ -28,7 +29,7 @@ describe("Creating and indexing a data item", function () {
     expect(d.rawData.toString()).toEqual("hello");
     expect(d.owner).toBe(wallet0.n);
     expect(d.target).toBe("OXcT1sVRSA5eGwt2k6Yuz8-3e3g9WJi5uSE99CWqsBs");
-    expect(d.anchor).toEqual("Math.apt'#]gng(36).substring(30)");
+    expect(d.anchor).toEqual(base64url.encode("Math.apt'#]gng(36).substring(30)"));
     expect(d.tags).toEqual([{ name: "Content-Type", value: "image/png" }]);
     expect(await DataItem.verify(d.getRaw())).toEqual(true);
   }, 5000000);
@@ -51,7 +52,7 @@ describe("Creating and indexing a data item", function () {
     expect(Buffer.from(d.rawData).toString()).toBe("tasty");
     expect(d.owner).toBe(wallet0.n);
     expect(d.target).toBe("");
-    expect(d.anchor).toEqual("Math.apt'#]gng(36).substring(30)");
+    expect(d.anchor).toEqual(base64url.encode("Math.apt'#]gng(36).substring(30)"));
     expect(d.tags).toEqual([
       {
         name: "testname",
@@ -140,7 +141,7 @@ describe("Creating and indexing a data item", function () {
     expect(Buffer.from(dataItems[0].rawData).toString()).toBe("tasty");
     expect(dataItems[0].owner).toBe(wallet0.n);
     expect(Buffer.from(dataItems[0].target).toString()).toBe("pFwvlpz1x_nebBPxkK35NZm522XPnvUSveGf4Pz8y4A");
-    expect(dataItems[0].anchor).toEqual("Math.randomgng(36).substring(30)");
+    expect(dataItems[0].anchor).toEqual(base64url.encode("Math.randomgng(36).substring(30)"));
     expect(dataItems[0].tags).toEqual([{ name: "x", value: "y" }]);
     expect(await DataItem.verify(dataItems[0].getRaw())).toEqual(true);
   });

--- a/src/file/FileDataItem.ts
+++ b/src/file/FileDataItem.ts
@@ -12,6 +12,7 @@ import axios from "axios";
 import { SIG_CONFIG } from "../constants";
 import { promisify } from "util";
 import { deserializeTags } from "../tags";
+import type { Base64URLString } from "../types";
 
 const read = promisify(FSRead);
 const write = promisify(FSWrite);
@@ -185,8 +186,8 @@ export class FileDataItem implements BundleItem {
     return Buffer.allocUnsafe(0);
   }
 
-  async anchor(): Promise<string> {
-    return (await this.rawAnchor()).toString();
+  async anchor(): Promise<Base64URLString> {
+    return base64url.encode(await this.rawAnchor());
   }
 
   async rawTags(): Promise<Buffer> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type Base64URLString = string;


### PR DESCRIPTION

This PR fixes DataItem & FileDataItem get anchor() returning rawAnchor.toString() instead of base64url.encode(rawAnchor)
additionally, this PR includes:
+ addition and usage of `Base64URLString` utility alias type
+ updates to all relevant tests
+ addition of `src/` to release package so that emitted sourceMaps function correctly